### PR TITLE
Add verboselogs, update example version to 23.3.1-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Added
+
+### Changed
+
+### Removed
+
+### Deprecated
+
+## [23.3.1-0] - 2023-06-12
+
+### Fixed
+
 - Fixed possible pygrads install issue
 
 ### Added
@@ -29,8 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicit Conda Packages
   - basemap
-
-### Deprecated
 
 ## [4.11.0] - 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Conda Packages
   - scikit-learn
   - yamllint
+  - verboselogs
 
 - Explicit Pip Packages
   - lxml
 
 ### Changed
 
-- Updated example version to 22.11.1-1
+- Updated example version to 23.3.1-0
 
 ### Removed
 

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -5,7 +5,7 @@
 # -----
 
 EXAMPLE_PY_VERSION="3.10"
-EXAMPLE_MINI_VERSION="22.11.1-1"
+EXAMPLE_MINI_VERSION="23.3.1-0"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -328,6 +328,7 @@ $PACKAGE_INSTALL zarr
 $PACKAGE_INSTALL scikit-learn
 
 $PACKAGE_INSTALL yamllint
+$PACKAGE_INSTALL verboselogs
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]


### PR DESCRIPTION
Per the request of @JulesKouatchou we add the `verboselog` package and ready for release.