### PR TITLE
Updates to use Python 3.11 and Miniconda 25.3.2-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [23.3.1-0] - 2023-07-06
+## [23.3.1-0] - 2023-07-11
 
 ### Fixed
 
@@ -40,9 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Pip Packages
   - lxml
 
+- Added example for ffnet
+
 ### Changed
 
 - Updated example version to 23.3.1-0
+- Explicit Pip Packages
+  - ffnet
+    - Moved to use a Git fork of the package to fix issues with Python3 and scipy
+    - Requires gfortran 8.3 or higher
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [23.5.0-3] - 2023-07-13
+## [23.5.0-3] - 2023-07-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicit Conda Packages
   - basemap
+  - cubes
 
 ## [4.11.0] - 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [23.3.1-0] - 2023-07-11
+## [23.5.0-3] - 2023-07-13
 
 ### Fixed
 
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - basemap (obsolete, use cartopy)
   - cubes (caused downgrade to Python 3.9)
   - gooey (caused downgrade of many packages)
+  - mdp (obsolete, not supported by 3.11)
 
 ## [4.11.0] - 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - libblas
     - Defaults to using `accelerate` on Arm-based macOS, and `mkl` on Intel-based macOS and Linux
   - movingpandas
+  - geoviews
+  - hvplot
+  - geopandas
 
 - Explicit Pip Packages
   - lxml
@@ -47,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated example version to 23.3.1-0
 - Explicit Pip Packages
   - ffnet
-    - Moved to use a Git fork of the package to fix issues with Python3 and scipy
+    - Moved to use a Git master branch of the package to fix issues with Python3 and scipy
     - Requires gfortran 8.3 or higher
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [23.3.1-0] - 2023-06-12
+## [23.3.1-0] - 2023-07-06
 
 ### Fixed
 
 - Fixed possible pygrads install issue
 
 ### Added
+
+- Added micromamba support (New Default Installer)
 
 - Explicit Conda Packages
   - scikit-learn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [23.5.0-3] - 2023-07-19
+## [23.5.2-0] - 2023-07-19
 
 ### Fixed
 
@@ -52,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated example version to 23.3.1-0
+- Updated example miniconda version to 23.5.2-0
+- Updated example Python version to 3.11
 - Explicit Pip Packages
   - ffnet
     - Moved to use a Git master branch of the package to fix issues with Python3 and scipy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - scikit-learn
   - yamllint
   - verboselogs
+  - libblas
+    - Defaults to using `accelerate` on Arm-based macOS, and `mkl` on Intel-based macOS and Linux
 
 - Explicit Pip Packages
   - lxml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - verboselogs
   - libblas
     - Defaults to using `accelerate` on Arm-based macOS, and `mkl` on Intel-based macOS and Linux
+  - movingpandas
 
 - Explicit Pip Packages
   - lxml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added micromamba support (New Default Installer)
+- Added micromamba support
+  - micromamba is a new, experimental, lightweight conda installer; we use it by default on macOS
+  - mamba is still default on Linux
 
 - Explicit Conda Packages
   - scikit-learn
@@ -44,8 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Explicit Conda Packages
-  - basemap
-  - cubes
+  - basemap (obsolete, use cartopy)
+  - cubes (caused downgrade to Python 3.9)
+  - gooey (caused downgrade of many packages)
 
 ## [4.11.0] - 2022-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed possible pygrads install issue
+- Fixed odd libcxx issue between miniconda and conda-forge
 
 ### Added
 
@@ -37,8 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Defaults to using `accelerate` on Arm-based macOS, and `mkl` on Intel-based macOS and Linux
   - movingpandas
   - geoviews
-  - hvplot
+  - hvplot (pinned to 0.8.3)
+  - bokeh (pinned to 3.1)
   - geopandas
+  - intake
+  - intake-parquet
+  - intake-xarray
 
 - Explicit Pip Packages
   - lxml

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -460,7 +460,7 @@ $PACKAGE_INSTALL virtualenv pipenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf pip biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
-$PACKAGE_INSTALL movingpandas
+$PACKAGE_INSTALL movingpandas geoviews hvplot geopandas
 
 # Looks like mo_pack, libmo_pack, pyspharm, windspharm are not available on arm64
 if [[ $MACH == arm64 ]]
@@ -545,11 +545,10 @@ $PIP_INSTALL lxml
 if [[ $ARCH == Linux ]]
 then
    $PIP_INSTALL f90wrap
-   # we need to install ffnet from https://github.com/GMAO-SI-Team/ffnet.git
+   # we need to install ffnet from https://github.com/mrkwjc/ffnet.git
    # This is because the version in PyPI is not compatible with Python 3
-   # We also install from a fork because the mother repo is not
-   # compatible with scipy 2 which no longer has a random method
-   $PIP_INSTALL git+https://github.com/GMAO-SI-Team/ffnet
+   # and latest scipy
+   $PIP_INSTALL git+https://github.com/mrkwjc/ffnet
 fi
 
 # Finally pygrads is not in pip

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -425,7 +425,7 @@ $PACKAGE_INSTALL pypng seaborn astropy
 $PACKAGE_INSTALL fastcache greenlet imageio jbig lzo
 # get_terminal_size are not on arm64
 if [[ $MACH != arm64 ]]
-else
+then
    $PACKAGE_INSTALL get_terminal_size
 fi
 $PACKAGE_INSTALL mock sphinxcontrib pytables

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -453,21 +453,26 @@ $PACKAGE_INSTALL "libblas=*=*${BLAS_IMPL}"
 # it is a directory so, in order for libcxx to be updated, we have to
 # remove it because the updater will fail
 #
-# First let's check the version of libcxx installed by asking conda
+# This seems to only happen on macOS
 
-LIBCXX_VERSION=$($MINICONDA_INSTALLDIR/bin/conda list libcxx | grep libcxx | awk '{print $2}')
-
-# This is the version X.Y.Z and we want to do things only if X is 14 as it's a directory in 15+
-# Let's use bash to extract the first number
-LIBCXX_MAJOR_VERSION=${LIBCXX_VERSION%%.*}
-MINICONDA_MAJOR_VERSION=${MINICONDA_VER%%.*}
-
-if [[ $LIBCXX_MAJOR_VERSION -lt 15 && $MINICONDA_MAJOR_VERSION -ge 23 ]]
+if [[ $ARCH == Darwin ]]
 then
-   if [[ -f $MINICONDA_INSTALLDIR/include/c++/v1/__string ]]
+   # First let's check the version of libcxx installed by asking conda
+
+   LIBCXX_VERSION=$($MINICONDA_INSTALLDIR/bin/conda list libcxx | grep libcxx | awk '{print $2}')
+
+   # This is the version X.Y.Z and we want to do things only if X is 14 as it's a directory in 15+
+   # Let's use bash to extract the first number
+   LIBCXX_MAJOR_VERSION=${LIBCXX_VERSION%%.*}
+   MINICONDA_MAJOR_VERSION=${MINICONDA_VER%%.*}
+
+   if [[ $LIBCXX_MAJOR_VERSION -lt 15 && $MINICONDA_MAJOR_VERSION -ge 23 ]]
    then
-      echo "Removing $MINICONDA_INSTALLDIR/include/c++/v1/__string"
-      rm $MINICONDA_INSTALLDIR/include/c++/v1/__string
+      if [[ -f $MINICONDA_INSTALLDIR/include/c++/v1/__string ]]
+      then
+         echo "Removing $MINICONDA_INSTALLDIR/include/c++/v1/__string"
+         rm $MINICONDA_INSTALLDIR/include/c++/v1/__string
+      fi
    fi
 fi
 

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -197,12 +197,17 @@ then
    if [[ $MACH == arm64 ]]
    then
       MICROMAMBA_ARCH=osx-arm64
+      BLAS_IMPL=accelerate
+      # Note: accelerate might have issues with scipy
+      #       See https://github.com/conda-forge/numpy-feedstock/issues/253
    else
       MICROMAMBA_ARCH=osx-64
+      BLAS_IMPL=mkl
    fi
 else
    MINICONDA_ARCH=Linux
    MICROMAMBA_ARCH=linux-64
+   BLAS_IMPL=mkl
 fi
 
 # -----------------------------------------------------
@@ -279,6 +284,7 @@ MINICONDA_BINDIR=$MINICONDA_INSTALLDIR/bin
 
 function conda_install {
    CONDA_INSTALL_COMMAND="$MINICONDA_BINDIR/conda install -y"
+   echo "CONDA_INSTALL_COMMAND = $CONDA_INSTALL_COMMAND"
 
    echo
    echo "(conda) Now installing $*"
@@ -334,6 +340,8 @@ fi
 # CONDA/MAMBA PACKAGES
 # --------------------
 
+$PACKAGE_INSTALL "libblas=*=*${BLAS_IMPL}"
+
 $PACKAGE_INSTALL esmpy
 $PACKAGE_INSTALL xesmf
 $PACKAGE_INSTALL pytest
@@ -342,24 +350,24 @@ $PACKAGE_INSTALL s3fs boto3
 
 $PACKAGE_INSTALL numpy scipy numba
 # We can't install mkl on arm64
-if [[ $MACH != arm64 ]]
-then
-   $PACKAGE_INSTALL mkl mkl-service mkl_fft mkl_random tbb tbb4py intel-openmp
-fi
+#if [[ $MACH != arm64 ]]
+#then
+   #$PACKAGE_INSTALL mkl mkl-service mkl_fft mkl_random tbb tbb4py intel-openmp
+#fi
 $PACKAGE_INSTALL netcdf4 cartopy proj matplotlib
 $PACKAGE_INSTALL virtualenv pipenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf pip biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
 
-# Looks like mo_pack, libmo_pack, pyspharm, windspharm, and cubes are not available on arm64
+# Looks like mo_pack, libmo_pack, pyspharm, windspharm are not available on arm64
 if [[ $MACH == arm64 ]]
 then
    $PACKAGE_INSTALL pygrib f90nml seawater
    $PACKAGE_INSTALL cmocean eofs
 else
    $PACKAGE_INSTALL pygrib f90nml seawater mo_pack libmo_unpack
-   $PACKAGE_INSTALL cmocean eofs pyspharm windspharm cubes
+   $PACKAGE_INSTALL cmocean eofs pyspharm windspharm
 fi
 
 $PACKAGE_INSTALL pyasn1 redis redis-py ujson mdp configobj argcomplete biopython

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -401,11 +401,6 @@ $PACKAGE_INSTALL xgcm
 $PACKAGE_INSTALL s3fs boto3
 
 $PACKAGE_INSTALL numpy scipy numba
-# We can't install mkl on arm64
-#if [[ $MACH != arm64 ]]
-#then
-   #$PACKAGE_INSTALL mkl mkl-service mkl_fft mkl_random tbb tbb4py intel-openmp
-#fi
 $PACKAGE_INSTALL netcdf4 cartopy proj matplotlib
 $PACKAGE_INSTALL virtualenv pipenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -57,8 +57,8 @@ fi
 # Usage
 # -----
 
-EXAMPLE_PY_VERSION="3.10"
-EXAMPLE_MINI_VERSION="23.3.1-0"
+EXAMPLE_PY_VERSION="3.11"
+EXAMPLE_MINI_VERSION="25.3.0-3"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -472,7 +472,12 @@ else
    $PACKAGE_INSTALL cmocean eofs pyspharm windspharm
 fi
 
-$PACKAGE_INSTALL pyasn1 redis redis-py ujson mdp configobj argcomplete biopython
+$PACKAGE_INSTALL pyasn1 redis redis-py ujson configobj argcomplete biopython
+# mdp only exists from 3.10 and older
+if [[ $PYTHON_VER_WITHOUT_DOT -le 310 ]]
+then
+   $PACKAGE_INSTALL mdp
+fi
 $PACKAGE_INSTALL requests-toolbelt twine wxpython
 $PACKAGE_INSTALL sockjs-tornado sphinx_rtd_theme django
 $PACKAGE_INSTALL pypng seaborn astropy

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -362,6 +362,7 @@ then
    MICROMAMBA_URL="https://micro.mamba.pm/api/micromamba/${MICROMAMBA_ARCH}/latest"
    curl -Ls ${MICROMAMBA_URL} | tar -C $MINICONDA_INSTALLDIR -xvj bin/micromamba
 elif [[ "$USE_MAMBA" == "TRUE" ]]
+then
    echo "=== Using mamba as package manager ==="
 
    conda_install mamba

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -73,9 +73,10 @@ usage() {
    echo "      --blas <blas> (default: ${BLAS_IMPL}, options: mkl, openblas, accelerate)"
    echo "      --conda: Use conda installer"
    echo "      --mamba: Use mamba installer"
+   echo "      --micromamba: Use micromamba installer"
    echo "      --help: Print this message"
    echo ""
-   echo "   By default we use the micromamba installer."
+   echo "   By default we use the micromamba installer on macOS and mamba on Linux"
    echo ""
    echo "   NOTE: This script installs within ${EXAMPLE_INSTALLDIR} with a path based on:"
    echo ""
@@ -132,9 +133,16 @@ fi
 # Command line arguments
 # ----------------------
 
-USE_CONDA=FALSE
-USE_MAMBA=FALSE
-USE_MICROMAMBA=TRUE
+if [[ $ARCH == Darwin ]]
+then
+   USE_CONDA=FALSE
+   USE_MAMBA=FALSE
+   USE_MICROMAMBA=TRUE
+else
+   USE_CONDA=FALSE
+   USE_MAMBA=TRUE
+   USE_MICROMAMBA=FALSE
+fi
 
 while [[ $# -gt 0 ]]
 do
@@ -149,11 +157,18 @@ do
          ;;
       --conda)
          USE_CONDA=TRUE
+         USE_MAMBA=FALSE
          USE_MICROMAMBA=FALSE
          ;;
       --mamba)
+         USE_CONDA=FALSE
          USE_MAMBA=TRUE
          USE_MICROMAMBA=FALSE
+         ;;
+      --micromamba)
+         USE_CONDA=FALSE
+         USE_MAMBA=FALSE
+         USE_MICROMAMBA=TRUE
          ;;
       --prefix)
          MINICONDA_DIR=$2
@@ -396,6 +411,7 @@ $PACKAGE_INSTALL virtualenv pipenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf pip biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
+$PACKAGE_INSTALL movingpandas
 
 # Looks like mo_pack, libmo_pack, pyspharm, windspharm are not available on arm64
 if [[ $MACH == arm64 ]]
@@ -410,14 +426,12 @@ fi
 $PACKAGE_INSTALL pyasn1 redis redis-py ujson mdp configobj argcomplete biopython
 $PACKAGE_INSTALL requests-toolbelt twine wxpython
 $PACKAGE_INSTALL sockjs-tornado sphinx_rtd_theme django
-# gooey and get_terminal_size are not on arm64
-if [[ $MACH == arm64 ]]
-then
-   $PACKAGE_INSTALL pypng seaborn astropy
-   $PACKAGE_INSTALL fastcache greenlet imageio jbig lzo
+$PACKAGE_INSTALL pypng seaborn astropy
+$PACKAGE_INSTALL fastcache greenlet imageio jbig lzo
+# get_terminal_size are not on arm64
+if [[ $MACH != arm64 ]]
 else
-   $PACKAGE_INSTALL gooey pypng seaborn astropy
-   $PACKAGE_INSTALL fastcache get_terminal_size greenlet imageio jbig lzo
+   $PACKAGE_INSTALL get_terminal_size
 fi
 $PACKAGE_INSTALL mock sphinxcontrib pytables
 $PACKAGE_INSTALL pydap

--- a/src/install_miniconda.bash
+++ b/src/install_miniconda.bash
@@ -72,18 +72,20 @@ usage() {
    echo "   Optional arguments:"
    echo "      --blas <blas> (default: ${BLAS_IMPL}, options: mkl, openblas, accelerate)"
    echo "      --conda: Use conda installer"
-   echo "      --micromamba: Use micromamba installer"
+   echo "      --mamba: Use mamba installer"
    echo "      --help: Print this message"
    echo ""
-   echo "  NOTE: This script installs within ${EXAMPLE_INSTALLDIR} with a path based on:"
+   echo "   By default we use the micromamba installer."
+   echo ""
+   echo "   NOTE: This script installs within ${EXAMPLE_INSTALLDIR} with a path based on:"
    echo ""
    echo "        1. The Miniconda version"
    echo "        2. The Python version"
    echo "        3. The date of the installation"
    echo ""
-   echo "  For example: $0 --python_version ${EXAMPLE_PY_VERSION} --miniconda_version ${EXAMPLE_MINI_VERSION} --prefix ${EXAMPLE_INSTALLDIR}"
+   echo "   For example: $0 --python_version ${EXAMPLE_PY_VERSION} --miniconda_version ${EXAMPLE_MINI_VERSION} --prefix ${EXAMPLE_INSTALLDIR}"
    echo ""
-   echo "  will create an install at:"
+   echo "   will create an install at:"
    echo "       ${EXAMPLE_INSTALLDIR}/${EXAMPLE_MINI_VERSION}_py${EXAMPLE_PY_VERSION}/${EXAMPLE_DATE}"
 }
 
@@ -131,7 +133,8 @@ fi
 # ----------------------
 
 USE_CONDA=FALSE
-USE_MICROMAMBA=FALSE
+USE_MAMBA=FALSE
+USE_MICROMAMBA=TRUE
 
 while [[ $# -gt 0 ]]
 do
@@ -146,9 +149,11 @@ do
          ;;
       --conda)
          USE_CONDA=TRUE
+         USE_MICROMAMBA=FALSE
          ;;
-      --micromamba)
-         USE_MICROMAMBA=TRUE
+      --mamba)
+         USE_MAMBA=TRUE
+         USE_MICROMAMBA=FALSE
          ;;
       --prefix)
          MINICONDA_DIR=$2
@@ -356,11 +361,14 @@ then
    echo "=== Installing micromamba ==="
    MICROMAMBA_URL="https://micro.mamba.pm/api/micromamba/${MICROMAMBA_ARCH}/latest"
    curl -Ls ${MICROMAMBA_URL} | tar -C $MINICONDA_INSTALLDIR -xvj bin/micromamba
-else
+elif [[ "$USE_MAMBA" == "TRUE" ]]
    echo "=== Using mamba as package manager ==="
 
    conda_install mamba
    PACKAGE_INSTALL=mamba_install
+else
+   echo "ERROR: No package manager selected! We should not get here. Exiting!"
+   exit 9
 fi
 
 # --------------------

--- a/src/tests/.gitignore
+++ b/src/tests/.gitignore
@@ -1,0 +1,3 @@
+xor.*
+__pycache__/
+*.py[cod]

--- a/src/tests/ffnet_example.py
+++ b/src/tests/ffnet_example.py
@@ -1,0 +1,12 @@
+from ffnet import ffnet, mlgraph, savenet, loadnet, exportnet
+conec = mlgraph( (2,2,1) )
+net = ffnet(conec)
+input = [ [0.,0.], [0.,1.], [1.,0.], [1.,1.] ]
+target  = [ [1.], [0.], [0.], [1.] ]
+net.train_tnc(input, target, maxfun = 1000)
+net.test(input, target, iprint = 2)
+savenet(net, "xor.net")
+exportnet(net, "xor.f")
+net = loadnet("xor.net")
+answer = net( [ 0., 0. ] )
+partial_derivatives = net.derivative( [ 0., 0. ] )


### PR DESCRIPTION
This PR has updates. It now supports Python 3.11 and the latest miniconda. It also moves to use micromamba as the package manager on macOS.

Note that it seems now `ffnet` requires at least gfortran 8.3