### PR TITLE
Update to Miniconda3 24.1.2 and Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - haversine
   - ford
   - autopep8
+  - mdutils
   - f90wrap (moved from pip)
 - Explicit Pip Packages
   - wordcloud (moved from conda)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Changed
+
+- Updated to miniconda 24.1.2-0
+- Updated to Python 3.12 by default
+- Use micromamba by default on Linux
+- Add BLIS as allowed BLAS
+- Added ability for ffnet to install on macOS
+  - The script looks for a gfortran compiler and if it finds one, it will install ffnet
+
 ### Added
 
 - Explicit Conda Packages
@@ -19,13 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Pip Packages
   - wordcloud (moved from conda)
   - meson (required for ffnet)
-
-### Changed
-
-- Updated to miniconda 24.1.2-0
-- Updated to Python 3.12 by default
-- Use micromamba by default on Linux
-- Add BLIS as allowed BLAS
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicit Conda Packages
   - haversine
+  - ford
 - Explicit Pip Packages
   - wordcloud (moved from conda)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - haversine
   - ford
   - autopep8
+  - f90wrap (moved from pip)
 - Explicit Pip Packages
   - wordcloud (moved from conda)
+  - meson (required for ffnet)
 
 ### Changed
 
@@ -32,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Pip Packages
   - theano (no longer maintained)
   - blaze (no longer maintained)
+  - f90wrap (moved to conda)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Added
+
+### Removed
+
+### Deprecated
+
+## [24.1.2] - 2024-04-04
+
+### Changed
+
 - Updated to Miniconda 24.1.2-0.
 - Updated to Python 3.12 by default.
 - Updated to use Micromamba by default on Linux.
 - Added BLIS as an allowed BLAS.
-- Added ability for ffnet to install on macOS
-  - Enhanced ffnet installation on macOS: The script now conditionally installs ffnet if a gfortran compiler is found.
+- Enhanced ffnet installation on macOS: The script now conditionally installs ffnet if a gfortran compiler is found.
 
 ### Added
 
@@ -25,9 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ford
   - autopep8
   - mdutils
-  - f90wrap (moved from pip)
+  - f90wrap (moved from Pip to Conda)
 - Explicit Pip Packages
-  - wordcloud (moved from conda)
+  - wordcloud (moved from Conda to Pip)
   - meson (required for ffnet)
 
 ### Removed
@@ -38,8 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - theano (no longer maintained)
   - blaze (no longer maintained)
   - f90wrap (moved to Conda from Pip)
-
-### Deprecated
 
 ## [23.5.2] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use micromamba by default on Linux
 - Add BLIS as allowed BLAS
 - Added ability for ffnet to install on macOS
-  - The script looks for a gfortran compiler and if it finds one, it will install ffnet
+  - Enhanced ffnet installation on macOS: The script now conditionally installs ffnet if a gfortran compiler is found.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Explicit Conda Packages
   - haversine
+- Explicit Pip Packages
+  - wordcloud (moved from conda)
 
 ### Changed
 
+- Updated to miniconda 24.1.2-0
+- Updated to Python 3.12 by default
 - Use micromamba by default on Linux
 - Add BLIS as allowed BLAS
 
 ### Removed
+
+- Explicit Conda Packages
+  - wordcloud (moved to pip)
+- Explicit Pip Packages
+  - theano (no longer maintained)
+  - blaze (no longer maintained)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to miniconda 24.1.2-0
 - Updated to Python 3.12 by default
-
-### Changed
-
-- Updated example miniconda version to 23.10.0-1
 - Use micromamba by default on Linux
 - Add BLIS as allowed BLAS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Explicit Conda Packages
-  - wordcloud (moved to pip)
+  - wordcloud (moved to Pip from Conda)
 - Explicit Pip Packages
   - theano (no longer maintained)
   - blaze (no longer maintained)
-  - f90wrap (moved to conda)
+  - f90wrap (moved to Conda from Pip)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to miniconda 24.1.2-0
-- Updated to Python 3.12 by default
-- Use micromamba by default on Linux
-- Add BLIS as allowed BLAS
+- Updated to Miniconda 24.1.2-0.
+- Updated to Python 3.12 by default.
+- Updated to use Micromamba by default on Linux.
+- Added BLIS as an allowed BLAS.
 - Added ability for ffnet to install on macOS
   - Enhanced ffnet installation on macOS: The script now conditionally installs ffnet if a gfortran compiler is found.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Conda Packages
   - haversine
   - ford
+  - autopep8
 - Explicit Pip Packages
   - wordcloud (moved from conda)
 
@@ -21,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to miniconda 24.1.2-0
 - Updated to Python 3.12 by default
+
+### Changed
+
+- Updated example miniconda version to 23.10.0-1
 - Use micromamba by default on Linux
 - Add BLIS as allowed BLAS
 

--- a/README.GMAO
+++ b/README.GMAO
@@ -1,5 +1,5 @@
 The command for installing on ford1 is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.11 --miniconda_version 23.5.2-0 --prefix /ford1/share/gmao_SIteam/GEOSpyD
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /ford1/share/gmao_SIteam/GEOSpyD
 ```

--- a/README.NAS
+++ b/README.NAS
@@ -1,5 +1,5 @@
 The command for installing on NAS systems is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.11 --miniconda_version 23.5.2-0 --prefix /nobackup/gmao_SIteam/GEOSpyD
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /nobackup/gmao_SIteam/GEOSpyD
 ```

--- a/README.NCCS
+++ b/README.NCCS
@@ -1,5 +1,5 @@
 The command for installing on NCCS system is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.11 --miniconda_version 23.5.2-0 --prefix /usr/local/other/python/GEOSpyD/
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /usr/local/other/python/GEOSpyD/
 ```

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ We do not
 In order to use the install script, you can run:
 
 ```
-./install_miniconda.bash --python_version 3.11 --miniconda_version 23.5.2-0 --prefix /opt/GEOSpyD
+./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /opt/GEOSpyD
 ```
 
 will create an install at:
 ```
-/opt/GEOSpyD/23.5.2-0_py3.11/YYYY-MM-DD
+/opt/GEOSpyD/24.1.2-0_py3.12/YYYY-MM-DD
 ```
 
 where YYYY-MM-DD is the date of the install. We use a date so that if
@@ -29,7 +29,7 @@ the stack is re-installed, the previous install is not overwritten.
 Usage: ./install_miniconda.bash --python_version <python version> --miniconda_version <miniconda_version> --prefix <prefix> [--conda]
 
    Required arguments:
-      --python_version <python version> (e.g., 3.11)
+      --python_version <python version> (e.g., 3.12)
       --miniconda_version <miniconda_version version> (e.g., 25.3.2-0)
       --prefix <full path to installation directory> (e.g, /opt/GEOSpyD)
 
@@ -49,10 +49,10 @@ Usage: ./install_miniconda.bash --python_version <python version> --miniconda_ve
         2. The Python version
         3. The date of the installation
 
-   For example: ./install_miniconda.bash --python_version 3.11 --miniconda_version 25.3.2-0 --prefix /opt/GEOSpyD
+   For example: ./install_miniconda.bash --python_version 3.12 --miniconda_version 25.3.2-0 --prefix /opt/GEOSpyD
 
    will create an install at:
-       /opt/GEOSpyD/25.3.2-0_py3.11/2024-03-08
+       /opt/GEOSpyD/25.3.2-0_py3.12/2024-03-08
 
   NOTE 2: This script will create or substitute a .condarc file in the user's home directory.
           If you have an existing .condarc file, it will be restored after installation.

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -548,6 +548,7 @@ $PACKAGE_INSTALL autopep8
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]
 then
+   $PACKAGE_INSTALL f90wrap
    $PACKAGE_INSTALL pythran
 fi
 
@@ -594,10 +595,16 @@ $PIP_INSTALL juliandate
 # on macs (though usually is)
 if [[ $ARCH == Linux ]]
 then
-   $PIP_INSTALL f90wrap
    # we need to install ffnet from https://github.com/mrkwjc/ffnet.git
    # This is because the version in PyPI is not compatible with Python 3
    # and latest scipy
+   #
+   # 1. This package now requirest meson to build (for Python 3.12)
+   $PIP_INSTALL meson
+   # 2. We also need f2py but that is in our install directory bin
+   #    so we need to add that to the PATH
+   export PATH=$MINICONDA_INSTALLDIR/bin:$PATH
+   # 3. Now we can install ffnet
    $PIP_INSTALL git+https://github.com/mrkwjc/ffnet
 fi
 

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -589,7 +589,6 @@ $PIP_INSTALL tensorflow evidential-deep-learning silence_tensorflow
 $PIP_INSTALL yaplon
 $PIP_INSTALL lxml
 $PIP_INSTALL juliandate
-$PIP_INSTALL wordcloud
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -543,6 +543,7 @@ $PACKAGE_INSTALL verboselogs
 $PACKAGE_INSTALL pykdtree pyogrio contourpy sunpy
 $PACKAGE_INSTALL haversine
 $PACKAGE_INSTALL ford
+$PACKAGE_INSTALL autopep8
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -635,8 +635,16 @@ then
    # 2. We also need f2py but that is in our install directory bin
    #    so we need to add that to the PATH
    export PATH=$MINICONDA_INSTALLDIR/bin:$PATH
-   # 3. Now we can install ffnet
+   # 3. We also should redefine TMPDIR as on some systems (discover)
+   #    it seems to not work as hoped. So, we create a new directory
+   #    relative to the install script called tmp, and use that.
+   #    It appears meson uses TMPDIR to store its build files.
+   mkdir -p $SCRIPTDIR/tmp-for-ffnet
+   export TMPDIR=$SCRIPTDIR/tmp-for-ffnet
+   # 4. Now we can install ffnet
    $PIP_INSTALL git+https://github.com/mrkwjc/ffnet
+   # 5. We can now remove the tmp directory
+   rm -rf $SCRIPTDIR/tmp-for-ffnet
 fi
 
 # Finally pygrads is not in pip

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -12,7 +12,7 @@ if [[ -f ~/.condarc ]]
 then
    CONDARC_FOUND=TRUE
    echo "Found existing .condarc. Saving to $ORIG_CONDARC"
-   cp -v ~/.condarc $ORIG_CONDARC
+   cp -v ~/.condarc "$ORIG_CONDARC"
 fi
 
 # The cleanup function will restore the user's .condarc
@@ -24,7 +24,7 @@ cleanup() {
    if [[ $CONDARC_FOUND == TRUE ]]
    then
       echo "Restoring original .condarc"
-      cp -v $ORIG_CONDARC ~/.condarc
+      cp -v "$ORIG_CONDARC" ~/.condarc
    fi
    exit $ret
 }

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -542,6 +542,7 @@ $PACKAGE_INSTALL verboselogs
 
 $PACKAGE_INSTALL pykdtree pyogrio contourpy sunpy
 $PACKAGE_INSTALL haversine
+$PACKAGE_INSTALL ford
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -58,8 +58,8 @@ fi
 # Usage
 # -----
 
-EXAMPLE_PY_VERSION="3.11"
-EXAMPLE_MINI_VERSION="25.3.2-0"
+EXAMPLE_PY_VERSION="3.12"
+EXAMPLE_MINI_VERSION="24.1.2-0"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -493,8 +493,7 @@ $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf pip biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
 # We need to pin hvplot due to https://github.com/movingpandas/movingpandas/issues/326
-# We need to pin bokeh as geoviews does not work with bokeh 3.2
-$PACKAGE_INSTALL movingpandas geoviews hvplot=0.8.3 geopandas bokeh=3.1
+$PACKAGE_INSTALL movingpandas geoviews hvplot=0.8.3 geopandas bokeh
 $PACKAGE_INSTALL intake intake-parquet intake-xarray
 
 # Looks like mo_pack, libmo_pack, pyspharm, windspharm are not available on arm64
@@ -534,7 +533,6 @@ $PACKAGE_INSTALL gsw
 
 $PACKAGE_INSTALL timezonefinder
 $PACKAGE_INSTALL cython
-$PACKAGE_INSTALL wordcloud
 $PACKAGE_INSTALL zarr
 
 $PACKAGE_INSTALL scikit-learn
@@ -581,7 +579,7 @@ $PACKAGE_INSTALL -c conda-forge/label/renamed nc_time_axis
 # ------------
 
 PIP_INSTALL="$MINICONDA_BINDIR/$PYTHON_EXEC -m pip install"
-$PIP_INSTALL PyRTF3 pipenv pymp-pypi rasterio theano blaze h5py
+$PIP_INSTALL PyRTF3 pipenv pymp-pypi rasterio h5py
 $PIP_INSTALL pycircleci metpy siphon questionary xgrads
 $PIP_INSTALL ruamel.yaml
 $PIP_INSTALL xgboost
@@ -589,6 +587,7 @@ $PIP_INSTALL tensorflow evidential-deep-learning silence_tensorflow
 $PIP_INSTALL yaplon
 $PIP_INSTALL lxml
 $PIP_INSTALL juliandate
+$PIP_INSTALL wordcloud
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -574,6 +574,7 @@ $PACKAGE_INSTALL pykdtree pyogrio contourpy sunpy
 $PACKAGE_INSTALL haversine
 $PACKAGE_INSTALL ford
 $PACKAGE_INSTALL autopep8
+$PACKAGE_INSTALL mdutils
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]


### PR DESCRIPTION
This PR updates GEOSpyD to use Miniconda3 24.1.2 and Python 3.12. With this come some changes:

- Add ford and autopep8 as a conda package
- wordcloud moves to a pip install
- theano and blaze are removed as no longer maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added explicit Conda packages: `ford`, `autopep8`, `mdutils`, `meson`.
    - Improved `ffnet` installation on macOS by checking for a gfortran compiler.
    - Added haversine package installation.
    - Included `BLIS` as an allowed BLAS.
- **Enhancements**
    - Transitioned to using `micromamba` by default on Linux.
    - Upgraded to Miniconda version 24.1.2-0.
    - Default Python version changed to 3.12.
- **Package Changes**
    - Moved `wordcloud` from Conda to Pip packages.
    - Removed `theano` from explicit Pip packages due to being no longer maintained.
    - Removed `blaze` from explicit Pip packages due to being no longer maintained.
    - Removed `f90wrap` from explicit Pip packages and moved it to Conda.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->