### PR TITLE
Add pybufrkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [24.1.2] - 2024-04-04
+## [24.1.2] - 2024-04-09
 
 ### Changed
 
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Pip Packages
   - wordcloud (moved from Conda to Pip)
   - meson (required for ffnet)
+  - pybufrkit
 
 ### Removed
 

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -621,6 +621,7 @@ $PIP_INSTALL tensorflow evidential-deep-learning silence_tensorflow
 $PIP_INSTALL yaplon
 $PIP_INSTALL lxml
 $PIP_INSTALL juliandate
+$PIP_INSTALL pybufrkit
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)


### PR DESCRIPTION
This PR adds pybufrkit (https://pybufrkit.readthedocs.io/en/latest/) to GEOSpyD. It enables reading and processing of BUFR files.