### PR TITLE
Use MacOSX backend on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
+
 ### Added
 
 ### Removed

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -674,9 +674,14 @@ cd $SCRIPTDIR
 find $MINICONDA_INSTALLDIR/lib -name 'exec_command.py' -print0 | xargs -0 $SED -i -e 's#^\( *\)use_shell = False#&\n\1command.insert(1, "-f")#'
 
 # Edit matplotlibrc to use TkAgg as the default backend for matplotlib
-# as that is the only backend that seems supported on all systems
+# on Linux, but MacOSX on macOS
 # --------------------------------------------------------------------
-find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -i -e '/^.*backend/ s%.*\(backend *:\).*%\1 TkAgg%'
+if [[ $ARCH == Darwin ]]
+then
+   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -i -e '/^.*backend/ s%.*\(backend *:\).*%\1 MacOSX%'
+else
+   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -i -e '/^.*backend/ s%.*\(backend *:\).*%\1 TkAgg%'
+fi
 
 # Use conda to output list of packages installed
 # ----------------------------------------------


### PR DESCRIPTION
As found by @JulesKouatchou and myself, the `MacOSX` backend seems to be a *LOT* better on macOS. This defaults to that on Darwin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated matplotlib backend settings for improved compatibility across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->