### PR TITLE
Update to miniconda 24.4, add earthaccess and pyephem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated to Miniconda 24.4.0-0.
-- Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
+- Use MacOSX matplotlib backend on macOS and TkAgg on Linux
   - Update sed command to make this change
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed another odd libcxx issue between miniconda and conda-forge (involving `tuple`)
+- Use fork of `ffnet` with fix for `setup.py` issue (see https://github.com/mrkwjc/ffnet/pull/11)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [24.4.0] - 2024-05-30
 
+### Fixed
+
+- Fixed another odd libcxx issue between miniconda and conda-forge (involving `tuple`)
+
 ### Changed
 
 - Updated to Miniconda 24.4.0-0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed another odd libcxx issue between miniconda and conda-forge (involving `tuple`)
 - Use fork of `ffnet` with fix for `setup.py` issue (see https://github.com/mrkwjc/ffnet/pull/11)
+- Fix issue with ipython (see https://github.com/ipython/ipython/issues/14260) by uninstalling
+  and re-installing `prompt_toolkit`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - earthaccess
 - Explicit Pip Packages
   - pyephem
+- Added ephem example
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to Miniconda 24.1.2-0.
+- Updated to Miniconda 24.4.0-0.
 - Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to Miniconda 24.4.0-0.
 - Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
+  - Update sed command to make this change
 
 ### Added
 
 - Explicit Conda Packages
   - earthaccess
-
 - Explicit Pip Packages
   - pyephem
+
+### Removed
+
+- Removed old sed command on `numpy` as file being altered no longer exists
 
 ## [24.1.2] - 2024-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
-
 ### Added
 
 ### Removed
 
 ### Deprecated
+
+## [24.4.0] - 2024-05-30
+
+### Changed
+
+- Updated to Miniconda 24.1.2-0.
+- Use MacOSX matplotlib backend on macOS, still use TkAgg on Linux
+
+### Added
+
+- Explicit Conda Packages
+  - earthaccess
+
+- Explicit Pip Packages
+  - pyephem
 
 ## [24.1.2] - 2024-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed another odd libcxx issue between miniconda and conda-forge (involving `tuple`)
-- Use fork of `ffnet` with fix for `setup.py` issue (see https://github.com/mrkwjc/ffnet/pull/11)
 - Fix issue with ipython (see https://github.com/ipython/ipython/issues/14260) by uninstalling
   and re-installing `prompt_toolkit`
 

--- a/README.GMAO
+++ b/README.GMAO
@@ -1,5 +1,5 @@
 The command for installing on ford1 is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /ford1/share/gmao_SIteam/GEOSpyD
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.4.0-0 --prefix /ford1/share/gmao_SIteam/GEOSpyD
 ```

--- a/README.NAS
+++ b/README.NAS
@@ -1,5 +1,5 @@
 The command for installing on NAS systems is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /nobackup/gmao_SIteam/GEOSpyD
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.4.0-0 --prefix /nobackup/gmao_SIteam/GEOSpyD
 ```

--- a/README.NCCS
+++ b/README.NCCS
@@ -1,5 +1,5 @@
 The command for installing on NCCS system is:
 
 ```
-$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /usr/local/other/python/GEOSpyD/
+$ ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.4.0-0 --prefix /usr/local/other/python/GEOSpyD/
 ```

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ We do not
 In order to use the install script, you can run:
 
 ```
-./install_miniconda.bash --python_version 3.12 --miniconda_version 24.1.2-0 --prefix /opt/GEOSpyD
+./install_miniconda.bash --python_version 3.12 --miniconda_version 24.4.0-0 --prefix /opt/GEOSpyD
 ```
 
 will create an install at:
 ```
-/opt/GEOSpyD/24.1.2-0_py3.12/YYYY-MM-DD
+/opt/GEOSpyD/24.4.0-0_py3.12/YYYY-MM-DD
 ```
 
 where YYYY-MM-DD is the date of the install. We use a date so that if

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage: ./install_miniconda.bash --python_version <python version> --miniconda_ve
 
    Required arguments:
       --python_version <python version> (e.g., 3.12)
-      --miniconda_version <miniconda_version version> (e.g., 25.3.2-0)
+      --miniconda_version <miniconda_version version> (e.g., 24.4.0-0)
       --prefix <full path to installation directory> (e.g, /opt/GEOSpyD)
 
    Optional arguments:
@@ -49,10 +49,10 @@ Usage: ./install_miniconda.bash --python_version <python version> --miniconda_ve
         2. The Python version
         3. The date of the installation
 
-   For example: ./install_miniconda.bash --python_version 3.12 --miniconda_version 25.3.2-0 --prefix /opt/GEOSpyD
+   For example: ./install_miniconda.bash --python_version 3.12 --miniconda_version 24.4.0-0 --prefix /opt/GEOSpyD
 
    will create an install at:
-       /opt/GEOSpyD/25.3.2-0_py3.12/2024-03-08
+       /opt/GEOSpyD/24.4.0-0_py3.12/2024-03-08
 
   NOTE 2: This script will create or substitute a .condarc file in the user's home directory.
           If you have an existing .condarc file, it will be restored after installation.

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -651,7 +651,7 @@ then
    mkdir -p $SCRIPTDIR/tmp-for-ffnet
    export TMPDIR=$SCRIPTDIR/tmp-for-ffnet
    # 4. Now we can install ffnet
-   $PIP_INSTALL git+https://github.com/mathomp4/ffnet
+   $PIP_INSTALL git+https://github.com/mrkwjc/ffnet
    # 5. We can now remove the tmp directory
    rm -rf $SCRIPTDIR/tmp-for-ffnet
 fi

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -619,6 +619,7 @@ $PACKAGE_INSTALL -c conda-forge/label/renamed nc_time_axis
 # ------------
 
 PIP_INSTALL="$MINICONDA_BINDIR/$PYTHON_EXEC -m pip install"
+PIP_UNINSTALL="$MINICONDA_BINDIR/$PYTHON_EXEC -m pip uninstall -y"
 $PIP_INSTALL PyRTF3 pipenv pymp-pypi rasterio h5py
 $PIP_INSTALL pycircleci metpy siphon questionary xgrads
 $PIP_INSTALL ruamel.yaml
@@ -691,6 +692,14 @@ then
 else
    find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -e '/.*backend:/ s/^.*backend:.*/backend: TkAgg/'
 fi
+
+# There currently seems to be a bug with ipython3
+# (see https://github.com/ipython/ipython/issues/14260)
+# the solution seems to be to pip uninstall prompt_toolkit
+# and then reinstall it. This is a temporary fix until
+# the issue is resolved.
+$PIP_UNINSTALL prompt_toolkit
+$PIP_INSTALL prompt_toolkit
 
 # Use conda to output list of packages installed
 # ----------------------------------------------

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -59,7 +59,7 @@ fi
 # -----
 
 EXAMPLE_PY_VERSION="3.12"
-EXAMPLE_MINI_VERSION="24.1.2-0"
+EXAMPLE_MINI_VERSION="24.4.0-0"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -575,6 +575,7 @@ $PACKAGE_INSTALL haversine
 $PACKAGE_INSTALL ford
 $PACKAGE_INSTALL autopep8
 $PACKAGE_INSTALL mdutils
+$PACKAGE_INSTALL earthaccess
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINICONDA_ARCH == Linux ]]
@@ -622,6 +623,7 @@ $PIP_INSTALL yaplon
 $PIP_INSTALL lxml
 $PIP_INSTALL juliandate
 $PIP_INSTALL pybufrkit
+$PIP_INSTALL pyephem
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -650,7 +650,7 @@ then
    mkdir -p $SCRIPTDIR/tmp-for-ffnet
    export TMPDIR=$SCRIPTDIR/tmp-for-ffnet
    # 4. Now we can install ffnet
-   $PIP_INSTALL git+https://github.com/mrkwjc/ffnet
+   $PIP_INSTALL git+https://github.com/mathomp4/ffnet
    # 5. We can now remove the tmp directory
    rm -rf $SCRIPTDIR/tmp-for-ffnet
 fi
@@ -676,18 +676,20 @@ find $MINICONDA_INSTALLDIR/lib -name 'gacm.py' -print0 | xargs -0 $SED -i -e '/c
 
 cd $SCRIPTDIR
 
-# Inject Joe Stassi's f2py shell fix into numpy
-# ---------------------------------------------
-find $MINICONDA_INSTALLDIR/lib -name 'exec_command.py' -print0 | xargs -0 $SED -i -e 's#^\( *\)use_shell = False#&\n\1command.insert(1, "-f")#'
-
 # Edit matplotlibrc to use TkAgg as the default backend for matplotlib
 # on Linux, but MacOSX on macOS
 # --------------------------------------------------------------------
+#
+# What we need to do is look for the string "backend:" in matplotlibrc
+# and change line (which might have one or more comment characters at
+# the beginning) to be "backend: MacOSX" on macOS and "backend: TkAgg"
+# on Linux.
+#
 if [[ $ARCH == Darwin ]]
 then
-   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -i -e '/^.*backend/ s%.*\(backend *:\).*%\1 MacOSX%'
+   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -e '/.*backend:/ s/^.*backend:.*/backend: MacOSX/'
 else
-   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -i -e '/^.*backend/ s%.*\(backend *:\).*%\1 TkAgg%'
+   find $MINICONDA_INSTALLDIR/lib -name 'matplotlibrc' -print0 | xargs -0 $SED -e '/.*backend:/ s/^.*backend:.*/backend: TkAgg/'
 fi
 
 # Use conda to output list of packages installed

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -507,6 +507,11 @@ then
          echo "Removing $MINICONDA_INSTALLDIR/include/c++/v1/__string"
          rm $MINICONDA_INSTALLDIR/include/c++/v1/__string
       fi
+      if [[ -f $MINICONDA_INSTALLDIR/include/c++/v1/__tuple ]]
+      then
+         echo "Removing $MINICONDA_INSTALLDIR/include/c++/v1/__tuple"
+         rm $MINICONDA_INSTALLDIR/include/c++/v1/__tuple
+      fi
    fi
 fi
 

--- a/tests/ephem_example.py
+++ b/tests/ephem_example.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+import ephem
+mars = ephem.Mars()
+mars.compute('2007/10/02 00:50:22')
+print(mars.ra, mars.dec)
+print("Should be: 6:05:56.34 23:23:40.0")
+print(ephem.constellation(mars))
+print("Should be: ('Gem', 'Gemini')")
+


### PR DESCRIPTION
This PR updates the default miniconda version to 24.4.0-0. 

We also add earthaccess as a new conda package and pyephem as a new pip package

Closes #17 
Closes #16 