### PR TITLE
Add f2py3 symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make a symlink of `f2py` to `f2py3` to fix an issue with the wrong `f2py` being found sometimes on discover
+
 ### Added
 
 ### Removed

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -608,6 +608,9 @@ cd $MINICONDA_INSTALLDIR/bin
 /bin/rm -v mpif77  && /bin/ln -sv esmf-mpifort       esmf-mpif77
 /bin/rm -v mpif90  && /bin/ln -sv esmf-mpifort       esmf-mpif90
 
+# We also want to link f2py to f2py3 for Python 3
+/bin/ln -sv f2py f2py3
+
 cd $SCRIPTDIR
 
 # Install weird nc_time_axis package


### PR DESCRIPTION
This PR adds a symlink of f2py to f2py3. This helps in the mixed python2/3 cases still sadly in use for GMAO