### PR TITLE
Add basemap as pip package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit Pip Packages
+  - basemap
+
 ### Removed
 
 ### Deprecated

--- a/install_miniconda.bash
+++ b/install_miniconda.bash
@@ -633,6 +633,7 @@ $PIP_INSTALL lxml
 $PIP_INSTALL juliandate
 $PIP_INSTALL pybufrkit
 $PIP_INSTALL pyephem
+$PIP_INSTALL basemap
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)


### PR DESCRIPTION
This PR adds basemap (back) to GEOSpyD as it seems to be being maintained again.