### PR TITLE
Fixes for micromamba installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix for new odd `micromamba` behaviors
+  - Set `MAMBA_ROOT_PREFIX`
+  - Set `use_lockfiles: False` in `.mambarc`
+
 ### Changed
+
+- Update example Miniconda version to 24.7.1-2
 
 ### Added
 

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -73,7 +73,7 @@ fi
 # -----
 
 EXAMPLE_PY_VERSION="3.12"
-EXAMPLE_MINI_VERSION="24.7.1-0"
+EXAMPLE_MINI_VERSION="24.7.1-2"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -418,6 +418,7 @@ channels:
   - nodefaults
 channel_priority: strict
 show_channel_urls: True
+use_lockfiles: False
 EOF
 
 cat << EOF > ~/.condarc
@@ -427,6 +428,7 @@ channels:
   - nodefaults
 channel_priority: strict
 show_channel_urls: True
+use_lockfiles: False
 EOF
 
 # ----------------------
@@ -437,6 +439,8 @@ if [[ ! -d $MINIFORGE_INSTALLDIR ]]
 then
    bash $MINIFORGE_SRCDIR/$INSTALLER -b -p $MINIFORGE_INSTALLDIR
 fi
+
+export MAMBA_ROOT_PREFIX=$MINIFORGE_INSTALLDIR
 
 MINIFORGE_BINDIR=$MINIFORGE_INSTALLDIR/bin
 


### PR DESCRIPTION
Recently, there have been weird issues seen with GEOSpyD installs by @JulesKouatchou.

Setting `MAMBA_ROOT_PREFIX` seems to help, but testing is ongoing.