### PR TITLE
Unpin hvplot; update example version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update example Miniconda version to 24.9.0-0
+- Update example Miniforge version to 24.9.0-0
 - Unpin `hvplot` version (see https://github.com/movingpandas/movingpandas/issues/326#issuecomment-2457862112)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update example Miniconda version to 24.7.1-2
+- Update example Miniconda version to 24.9.0-0
+- Unpin `hvplot` version (see https://github.com/movingpandas/movingpandas/issues/326#issuecomment-2457862112)
 
 ### Added
 

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -73,7 +73,7 @@ fi
 # -----
 
 EXAMPLE_PY_VERSION="3.12"
-EXAMPLE_MINI_VERSION="24.7.1-2"
+EXAMPLE_MINI_VERSION="24.9.0-0"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -547,8 +547,7 @@ $PACKAGE_INSTALL virtualenv pipenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf pip biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
-# We need to pin hvplot due to https://github.com/movingpandas/movingpandas/issues/326
-$PACKAGE_INSTALL movingpandas geoviews hvplot=0.8.3 geopandas bokeh
+$PACKAGE_INSTALL movingpandas geoviews hvplot geopandas bokeh
 $PACKAGE_INSTALL intake intake-parquet intake-xarray
 
 # Looks like mo_pack, libmo_pack, pyspharm, windspharm are not available on arm64


### PR DESCRIPTION
This PR unpins the `hvplot` as a bug as apparently been fixed (see
movingpandas/movingpandas#326)

Also, move to use version 24.9.0-0 in examples