### PR TITLE
Fixes for ipython (pin sqlite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-## [24.11.3] - 2025-02-25
+## [24.11.3] - 2025-03-03
 
 ### Fixed
 
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin `hvplot` version to ">=0.11.0" (see [movingpandas#326](https://github.com/movingpandas/movingpandas/issues/326#issuecomment-2457862112))
 - Issues with Python 3.13
   - Only install `tensorflow` packages if Python 3.12 or lower. It currently has issues with Python 3.13 (see https://github.com/tensorflow/tensorflow/issues/78774)
+- Pin `sqlite` to version 3.48.0
+  - It was found that with some older and newer versions of `sqlite`, `ipython` would not run and would throw errors
+    as seen in [this issue](https://stackoverflow.com/questions/78990030/undefined-symbol-sqlite3-deserialize-in-jupyter-notebook-visual-studio-code)
+    Pinning to 3.48.0 seems to fix this issue for now.
 
 ### Added
 

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -614,6 +614,9 @@ $PACKAGE_INSTALL earthaccess
 
 $PACKAGE_INSTALL uxarray
 
+# We seem to need to require sqlite 3.48.0 *exactly* for ipython3
+$PACKAGE_INSTALL sqlite"==3.48.0"
+
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINIFORGE_ARCH == Linux ]]
 then

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -615,6 +615,7 @@ $PACKAGE_INSTALL earthaccess
 $PACKAGE_INSTALL uxarray
 
 # We seem to need to require sqlite 3.48.0 *exactly* for ipython3
+# NOTE: This might need to be revisited in the next version
 $PACKAGE_INSTALL sqlite"==3.48.0"
 
 # Only install pythran on linux. On mac it brings in an old clang


### PR DESCRIPTION
We need to pin the version of `sqlite` to allow ipython to work. See https://stackoverflow.com/questions/78990030/undefined-symbol-sqlite3-deserialize-in-jupyter-notebook-visual-studio-code for some more info.