### PR TITLE
Add cdo and nco

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Explicit Pip Packages
+  - nco
+  - cdo
+
 ### Removed
 
 ### Deprecated

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -686,6 +686,8 @@ fi
 $PIP_INSTALL redis
 $PIP_INSTALL Flask
 $PIP_INSTALL goes2go
+$PIP_INSTALL nco
+$PIP_INSTALL cdo
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)


### PR DESCRIPTION
Closes #33 
Closes #32 

This PR adds the nco and cdo Python bindings. As @viral211 pointed out to me, if installed via `pip`, we don't pull down any executables, so it would use the ones from Baselibs. Seems safe!