### PR TITLE
Add contextily, allow 3.13 Tensorflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update example Miniforge version to 25.3.0-3
+- Update example Miniforge version to 25.3.1-3
 - Update example Python version to 3.13
 - Re-enable `basemap` installation by default
   - This is now possible as `basemap` has been updated to support `numpy` v2
 - Rename `always_circular_stereo.py` to `cartopy_example.py`
+- Enable TensorFlow installation for Python 3.13
+  - This is now possible as TensorFlow has been updated to support Python 3.13
 
 ### Added
 
+- Explicit Conda Packages
+  - contextily
 - Explicit Pip Packages
   - nco
   - cdo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Pip Packages
   - nco
   - cdo
+- Add new pytorch test
 
 ### Removed
+
+- Removed `sqlite` fix as it doesn't seem needed anymore for `ipython`
 
 ### Deprecated
 

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -605,10 +605,6 @@ $PACKAGE_INSTALL uxarray
 
 $PACKAGE_INSTALL contextily
 
-# We seem to need to require sqlite 3.48.0 *exactly* for ipython3
-# NOTE: This might need to be revisited in the next version
-#$PACKAGE_INSTALL sqlite"==3.48.0"
-
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINIFORGE_ARCH == Linux ]]
 then

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -73,7 +73,7 @@ fi
 # -----
 
 EXAMPLE_PY_VERSION="3.13"
-EXAMPLE_MINI_VERSION="25.3.0-3"
+EXAMPLE_MINI_VERSION="25.3.1-0"
 EXAMPLE_INSTALLDIR="/opt/GEOSpyD"
 EXAMPLE_DATE=$(date +%F)
 usage() {
@@ -603,9 +603,11 @@ $PACKAGE_INSTALL earthaccess
 
 $PACKAGE_INSTALL uxarray
 
+$PACKAGE_INSTALL contextily
+
 # We seem to need to require sqlite 3.48.0 *exactly* for ipython3
 # NOTE: This might need to be revisited in the next version
-$PACKAGE_INSTALL sqlite"==3.48.0"
+#$PACKAGE_INSTALL sqlite"==3.48.0"
 
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINIFORGE_ARCH == Linux ]]
@@ -653,12 +655,7 @@ $PIP_INSTALL PyRTF3 pipenv pymp-pypi rasterio h5py
 $PIP_INSTALL pycircleci metpy siphon questionary xgrads
 $PIP_INSTALL ruamel.yaml
 $PIP_INSTALL xgboost
-# At the moment tensorflow does not support Python 3.13
-# See https://github.com/tensorflow/tensorflow/issues/78774
-if [[ $PYTHON_VER_WITHOUT_DOT -lt 313 ]]
-then
-   $PIP_INSTALL tensorflow evidential-deep-learning silence_tensorflow
-fi
+$PIP_INSTALL tensorflow evidential-deep-learning silence_tensorflow
 $PIP_INSTALL torch
 $PIP_INSTALL yaplon
 $PIP_INSTALL lxml

--- a/tests/torch_example.py
+++ b/tests/torch_example.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import torch
+import math
+
+
+dtype = torch.float
+device = torch.device("cpu")
+# device = torch.device("cuda:0") # Uncomment this to run on GPU
+
+# Create random input and output data
+x = torch.linspace(-math.pi, math.pi, 2000, device=device, dtype=dtype)
+y = torch.sin(x)
+
+# Randomly initialize weights
+a = torch.randn((), device=device, dtype=dtype)
+b = torch.randn((), device=device, dtype=dtype)
+c = torch.randn((), device=device, dtype=dtype)
+d = torch.randn((), device=device, dtype=dtype)
+
+learning_rate = 1e-6
+for t in range(2000):
+    # Forward pass: compute predicted y
+    y_pred = a + b * x + c * x ** 2 + d * x ** 3
+
+    # Compute and print loss
+    loss = (y_pred - y).pow(2).sum().item()
+    if t % 100 == 99:
+        print(t, loss)
+
+    # Backprop to compute gradients of a, b, c, d with respect to loss
+    grad_y_pred = 2.0 * (y_pred - y)
+    grad_a = grad_y_pred.sum()
+    grad_b = (grad_y_pred * x).sum()
+    grad_c = (grad_y_pred * x ** 2).sum()
+    grad_d = (grad_y_pred * x ** 3).sum()
+
+    # Update weights using gradient descent
+    a -= learning_rate * grad_a
+    b -= learning_rate * grad_b
+    c -= learning_rate * grad_c
+    d -= learning_rate * grad_d
+
+
+print(f'Result: y = {a.item()} + {b.item()} x + {c.item()} x^2 + {d.item()} x^3')


### PR DESCRIPTION
Closes #36 
Closes #28 

This PR:

- Add `contextily` as a new package
- Allows Tensorflow to install with Python 3.13
- Removes the ipython sqlite fix
- Adds a torch fix