### PR TITLE
Add extra libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [26.1.1-3] - 2026-04-03
+## [26.1.1-3] - 2026-05-01
 
 ### Fixed
 
@@ -44,8 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CPU vs. Accelerated (CUDA/MPS) comparisons to PyTorch tests (`tests/torch_example.py` and `tests/torch_example_like_tflow.py`)
 - Explicit Conda Packages
   - basemap (latest version for Python 3.14 support only on conda-forge)
+  - jupyter_bokeh
 - Explicit Pip Packages
   - python-docx
+  - openpyxl
+  - python-magic
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicit Conda Packages
   - basemap (latest version for Python 3.14 support only on conda-forge)
   - jupyter_bokeh
+  - libmagic & python-magic
 - Explicit Pip Packages
   - python-docx
   - openpyxl
-  - python-magic
 
 ### Removed
 

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -551,7 +551,7 @@ $PACKAGE_INSTALL virtualenv configargparse
 $PACKAGE_INSTALL psycopg2 gdal xarray geotiff plotly
 $PACKAGE_INSTALL iris pyhdf biggus hpccm cdsapi
 $PACKAGE_INSTALL babel beautifulsoup4 colorama gmp jupyter jupyterlab
-$PACKAGE_INSTALL movingpandas geoviews hvplot">=0.11.0" geopandas bokeh
+$PACKAGE_INSTALL movingpandas geoviews hvplot">=0.11.0" geopandas bokeh jupyter_bokeh
 $PACKAGE_INSTALL skimpy
 $PACKAGE_INSTALL intake intake-parquet intake-xarray
 
@@ -675,6 +675,8 @@ $PIP_INSTALL nco
 $PIP_INSTALL cdo
 $PIP_INSTALL ecmwf-opendata
 $PIP_INSTALL python-docx
+$PIP_INSTALL openpyxl
+$PIP_INSTALL python-magic
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)

--- a/install_miniforge.bash
+++ b/install_miniforge.bash
@@ -607,6 +607,8 @@ $PACKAGE_INSTALL rasterio contextily
 
 $PACKAGE_INSTALL basemap
 
+$PACKAGE_INSTALL libmagic python-magic
+
 # Only install pythran on linux. On mac it brings in an old clang
 if [[ $MINIFORGE_ARCH == Linux ]]
 then
@@ -676,7 +678,6 @@ $PIP_INSTALL cdo
 $PIP_INSTALL ecmwf-opendata
 $PIP_INSTALL python-docx
 $PIP_INSTALL openpyxl
-$PIP_INSTALL python-magic
 
 # some packages require a Fortran compiler. This sometimes isn't available
 # on macs (though usually is)


### PR DESCRIPTION
This PR adds:

- jupyter_bokeh
- openpxyl
- python-magic

to GEOSpyD. We will push the 26.1.1-3 tag since it hasn't been deployed anywhere yet.

Closes #44 
Closes #43 
Closes #42 